### PR TITLE
bugfix: Benchmark `ltl2dpa22.tlsf`

### DIFF
--- a/benchmarks/tlsf/acaciaplus/ltl2dpa22.tlsf
+++ b/benchmarks/tlsf/acaciaplus/ltl2dpa22.tlsf
@@ -13,7 +13,7 @@ MAIN {
     a3;
     a4;
     a5;
-    b
+    b;
   }
 
   OUTPUTS {


### PR DESCRIPTION
This PR adds a missing semicolon to benchmark `ltl2dpa22.tlsf`.